### PR TITLE
CentOS 7: remove dead updates-source repository

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -59,3 +59,6 @@ RUN sed -e '/\[centos-sclo-rh-source\]/,+6d' -i /etc/yum.repos.d/CentOS-SCLo-scl
 #
 # The output above means that the problem is there.
 RUN sed -e '/\[extras-source\]/,+6d' -i /etc/yum.repos.d/CentOS-Sources.repo
+
+# The same as above, but for the updates-source repository.
+RUN sed -e '/\[updates-source\]/,+6d' -i /etc/yum.repos.d/CentOS-Sources.repo


### PR DESCRIPTION
update from upstream